### PR TITLE
Firefox < 50 support

### DIFF
--- a/snippet/main.js
+++ b/snippet/main.js
@@ -135,4 +135,4 @@ if (typeof window !== 'undefined')
   window.VoteNow = Snippet;
 
 if (typeof document !== 'undefined')
-  document.querySelectorAll('.votenow').forEach(elem => new Snippet(elem));
+  Array.prototype.slice.call(document.querySelectorAll('.votenow')).forEach(elem => new Snippet(elem));


### PR DESCRIPTION
In Firefox < 50 (https://developer.mozilla.org/en-US/Firefox/Releases/50#DOM) forEach requires an Array and was failing with:
`TypeError: document.querySelectorAll(...).forEach is not a function`